### PR TITLE
Create the live-search-maxlength parameter

### DIFF
--- a/liveSearch.js
+++ b/liveSearch.js
@@ -11,7 +11,8 @@ angular.module("LiveSearch", ["ng"])
             liveSearchSelectCallback: '=',
             liveSearchItemTemplate: '@',
             liveSearchWaitTimeout: '=?',
-            liveSearchMaxResultSize: '=?'
+            liveSearchMaxResultSize: '=?',
+            liveSearchMaxlength: '=?'
         },
         template: "<input type='text' />",
         link: function (scope, element, attrs, controller) {
@@ -101,7 +102,8 @@ angular.module("LiveSearch", ["ng"])
                 var vals = target.val().split(",");
                 var search_string = vals[vals.length - 1].trim();
                 // Do Search
-                if (search_string.length < 3 || search_string.length > 9) {
+                if (search_string.length < 3 ||
+                    (scope.liveSearchMaxlength !== null && search_string.length > scope.liveSearchMaxlength)) {
                     scope.visible = false;
                     //unmanaged code needs to force apply
                     scope.$apply();


### PR DESCRIPTION
Closes mauriciogentile/angular-livesearch#7.

Closes 18F/hub#119.

As mentioned in the above issues, the nine-character query string limit was
problematic for our use case. This effectively removes the limit, but users
can elect to limit the maximum query string limit by setting the
`live-search-maxlength` attribute.

Also fixes the `should not invoke search callback if input length is less than
3` test spec, as I could not make the test fail until applying the updates
from this commit.

cc: @afeld @shawnbot @msecret @vzvenyach